### PR TITLE
Fix: false negatives hardcoded table path

### DIFF
--- a/pre_commit_dbt/check_script_has_no_table_name.py
+++ b/pre_commit_dbt/check_script_has_no_table_name.py
@@ -52,6 +52,7 @@ def has_table_name(
 ) -> Tuple[int, Set[str]]:
     status_code = 0
     sql_clean = replace_comments(sql)
+    sql_clean = replace_reserved_functions(sql)
     sql_clean = add_space_to_parenthesis(sql_clean)
     sql_clean = add_space_to_source_ref(sql_clean)
     sql_split = re.split(REGEX_SPLIT, sql_clean)

--- a/pre_commit_dbt/check_script_has_no_table_name.py
+++ b/pre_commit_dbt/check_script_has_no_table_name.py
@@ -12,6 +12,9 @@ from pre_commit_dbt.utils import add_filenames_args
 REGEX_COMMENTS = (
     r"(?<=(\/\*|\{#))((.|[\r\n])+?)(?=(\*+\/|#\}))|[ \t]*--.*"
 )
+REGEX_JINJA_LOGIC = (
+    r"\{%\s*if\s+[^%]*\s*%\}"
+)
 REGEX_RESERVED = r"is (not )?distinct from"
 REGEX_SPLIT = r"[\s]+"
 IGNORE_WORDS = ["", "(", "{{","simple_cte"]  # pragma: no mutate
@@ -37,6 +40,9 @@ def prev_cur_next_iter(
 def replace_comments(sql: str) -> str:
     return re.sub(REGEX_COMMENTS, "", sql)
 
+def replace_jinja_logic(sql: str) -> str:
+    return re.sub(REGEX_JINJA_LOGIC, "", sql, flags=re.IGNORECASE)
+
 def replace_reserved_functions(sql: str) -> str:
     return re.sub(REGEX_RESERVED, "", sql, flags=re.IGNORECASE)
 
@@ -52,6 +58,7 @@ def has_table_name(
 ) -> Tuple[int, Set[str]]:
     status_code = 0
     sql_clean = replace_comments(sql)
+    sql_clean = replace_jinja_logic(sql_clean)
     sql_clean = replace_reserved_functions(sql_clean)
     sql_clean = add_space_to_parenthesis(sql_clean)
     sql_clean = add_space_to_source_ref(sql_clean)

--- a/pre_commit_dbt/check_script_has_no_table_name.py
+++ b/pre_commit_dbt/check_script_has_no_table_name.py
@@ -52,7 +52,7 @@ def has_table_name(
 ) -> Tuple[int, Set[str]]:
     status_code = 0
     sql_clean = replace_comments(sql)
-    sql_clean = replace_reserved_functions(sql)
+    sql_clean = replace_reserved_functions(sql_clean)
     sql_clean = add_space_to_parenthesis(sql_clean)
     sql_clean = add_space_to_source_ref(sql_clean)
     sql_split = re.split(REGEX_SPLIT, sql_clean)

--- a/pre_commit_dbt/check_script_has_no_table_name.py
+++ b/pre_commit_dbt/check_script_has_no_table_name.py
@@ -12,6 +12,7 @@ from pre_commit_dbt.utils import add_filenames_args
 REGEX_COMMENTS = (
     r"(?<=(\/\*|\{#))((.|[\r\n])+?)(?=(\*+\/|#\}))|[ \t]*--.*"
 )
+REGEX_RESERVED = r"is (not )?distinct from"
 REGEX_SPLIT = r"[\s]+"
 IGNORE_WORDS = ["", "(", "{{","simple_cte"]  # pragma: no mutate
 REGEX_PARENTHESIS = r"([\(\)])"  # pragma: no mutate
@@ -36,6 +37,8 @@ def prev_cur_next_iter(
 def replace_comments(sql: str) -> str:
     return re.sub(REGEX_COMMENTS, "", sql)
 
+def replace_reserved_functions(sql: str) -> str:
+    return re.sub(REGEX_RESERVED, "", sql, flags=re.IGNORECASE)
 
 def add_space_to_parenthesis(sql: str) -> str:
     return re.sub(REGEX_PARENTHESIS, r" \1 ", sql)


### PR DESCRIPTION
# Purpose

The `check-script-has-no-table-name` hook is catching false positives, which are blocking [this PR](https://github.com/vercel/data-dbt/pull/1144) from merging cleanly (e.g. without exclusion lists) in our internal repository.

This PR changes the hook logic to ignore those edge cases.

# Details

- Ignore reserved functions: `is distinct from` and `is not distinct from` (which are not `from` functions)
- Ignore if jinja logic: example `{% if is_incremental() %}`
  Note: In that context, it will only test the table in the first `if` logic. Other tables will not be tested. Since this is very rare, non-blocking (false negative), and this would require to complicate the overall logic, this edge case has been purposefully ignored.

# Validation

Cloned this repo and copied the hook in our dbt repo from [cleanup/remove-table-path](https://github.com/vercel/data-dbt/tree/cleanup/remove-table-path) using the local commit:
```
    - repo: ../pre-commit-dbt
      rev: 0f9267e596d62f437122c3d4bedc72211d059807
      hooks:
        - id: check-script-has-no-table-name
          name: Check only source or ref macro is used to specify the table name.
          files: models/
          exclude: |
            (?x)(
              models/prod/workspaces/workspace_data/data_infra/fct_snowflake_query_history_prod.sql
            )
```

Comparison:
<img width="976" alt="image" src="https://github.com/stephanesol/pre-commit-dbt/assets/28601386/81349d61-99f8-44fc-a95b-6d0b04756444">

- ✅ No new fail cases
- ✅ Edge cases fixed

# Note
Have never used the release/version tag feature, please let me know if I need to add something to this PR 🙏 
