### PR TITLE
Fix: false negative 'from' strings for hardcoded table path

### DIFF
--- a/pre_commit_dbt/check_script_has_no_table_name.py
+++ b/pre_commit_dbt/check_script_has_no_table_name.py
@@ -15,6 +15,7 @@ REGEX_COMMENTS = (
 REGEX_JINJA_LOGIC = (
     r"\{%\s*if\s+[^%]*\s*%\}"
 )
+REGEX_STRING_LITERAL = r"'[^']*?'"
 REGEX_RESERVED = r"is (not )?distinct from"
 REGEX_SPLIT = r"[\s]+"
 IGNORE_WORDS = ["", "(", "{{","simple_cte"]  # pragma: no mutate
@@ -43,6 +44,9 @@ def replace_comments(sql: str) -> str:
 def replace_jinja_logic(sql: str) -> str:
     return re.sub(REGEX_JINJA_LOGIC, "", sql, flags=re.IGNORECASE)
 
+def replace_string_literals(sql: str) -> str:
+    return re.sub(REGEX_STRING_LITERAL, "", sql)
+
 def replace_reserved_functions(sql: str) -> str:
     return re.sub(REGEX_RESERVED, "", sql, flags=re.IGNORECASE)
 
@@ -59,6 +63,7 @@ def has_table_name(
     status_code = 0
     sql_clean = replace_comments(sql)
     sql_clean = replace_jinja_logic(sql_clean)
+    sql_clean = replace_string_literals(sql_clean)
     sql_clean = replace_reserved_functions(sql_clean)
     sql_clean = add_space_to_parenthesis(sql_clean)
     sql_clean = add_space_to_source_ref(sql_clean)


### PR DESCRIPTION
# Purpose

The `check-script-has-no-table-name` hook is catching new false positives ([known issue](https://github.com/dbt-checkpoint/dbt-checkpoint/issues/36#issuecomment-1087075481)), which are blocking https://github.com/vercel/data-dbt/pull/1742 from merging cleanly (e.g. without exclusion lists) in our internal repository.

This Pull Request changes the hook logic to ignore those edge cases.

Resolves https://github.com/vercel/data/issues/2694

# Details

Ignore all string literals → avoid catching `'foo from bar'`

# Validation

## Local tests
Test passing

<img width="962" alt="Screenshot 2024-10-29 at 10 34 47 AM" src="https://github.com/user-attachments/assets/77b72c08-8088-491b-a07e-f84e972691c0">

## Testing on blocked Pull Request
Cloned this repo and copied the hook in our dbt repo from [feat/ent_subscription_products_mrr](https://github.com/vercel/data-dbt/tree/feat/ent_subscription_products_mrr) using the local commit:
```
    - repo: ../pre-commit-dbt
      rev: 3df1a117caffad5a1feb695faed128313d6741e4
      hooks:
        - id: check-script-has-no-table-name
          name: Check only source or ref macro is used to specify the table name.
          files: models/
          exclude: |
            (?x)(
              models/prod/workspaces/workspace_data/data_infra/fct_snowflake_query_history_prod.sql
            )
```

Comparison:
![image](https://github.com/user-attachments/assets/1851a3ed-dd13-43c7-b4e3-909ee6518649)


- ✅ No new fail cases
- ✅ Edge cases fixed